### PR TITLE
chore: update Rust edition from 2021 to 2024 in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "text_invert"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }


### PR DESCRIPTION
Fixes #34