### PR TITLE
feat: add palindrome check functionality

### DIFF
--- a/tests/main.rs
+++ b/tests/main.rs
@@ -14,3 +14,12 @@ fn test_main_empty_input() {
         .failure()
         .stderr("error: a value is required for '--word <WORD>' but none was supplied\n\nFor more information, try '--help'.\n");
 }
+
+#[test]
+fn test_main_palindrome_flag() {
+    let mut cmd = Command::cargo_bin("text_invert").unwrap();
+    cmd.args(["--word=racecar", "--palindrome"]).assert().success().stdout("racecar is a palindrome\n");
+
+    let mut cmd = Command::cargo_bin("text_invert").unwrap();
+    cmd.args(["--word=hello", "-p"]).assert().success().stdout("hello is not a palindrome\n");
+}


### PR DESCRIPTION
This pull request enhances the functionality of the `text_invert` application by adding a feature to check if words are palindromes. It introduces a new command-line flag (`--palindrome` or `-p`) and updates the codebase to support this functionality while maintaining the existing word reversal feature. Additionally, it includes comprehensive test cases to ensure the correctness of the new feature.

### New Feature: Palindrome Check
* Added a `--palindrome` (`-p`) flag to the `Args` struct, allowing users to check if the provided words are palindromes instead of reversing them. (`src/main.rs`, [src/main.rsL10-R44](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL10-R44))
* Implemented the `is_palindrome` function to determine if a word is a palindrome by comparing its characters in a case-insensitive manner. (`src/main.rs`, [src/main.rsL10-R44](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL10-R44))
* Updated the `run` function to handle the palindrome check logic when the `--palindrome` flag is provided. (`src/main.rs`, [src/main.rsL10-R44](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL10-R44))

### Updates to Main Functionality
* Modified the `main` function to pass the `palindrome` flag to the `run` function in each thread, ensuring the correct behavior based on user input. (`src/main.rs`, [src/main.rsL35-R56](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL35-R56))

### Testing Enhancements
* Added unit tests for the new `is_palindrome` function to validate its behavior with various inputs, including edge cases. (`src/main.rs`, [src/main.rsR83-R100](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR83-R100))
* Extended the `test_run` function to include test cases for the palindrome check functionality. (`src/main.rs`, [src/main.rsR83-R100](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR83-R100))
* Added integration tests in `mod tests` and `tests/main.rs` to verify the behavior of the `--palindrome` flag in the application, ensuring correct outputs for both palindromes and non-palindromes. (`src/main.rs`, [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR136-R162); `tests/main.rs`, [[2]](diffhunk://#diff-cc856031f5a2bd26067d2ed100ee6e0dc576d5ed7c354a6f223468b7e5b85664R17-R25)